### PR TITLE
Fix user id retrieval and update unit test

### DIFF
--- a/app/bot_runner.py
+++ b/app/bot_runner.py
@@ -215,7 +215,7 @@ class QuizBot:
         context.user_data["state"] = SELECTING_ACTION
         
     async def command_quiz(self, update: Update, context: CallbackContext):
-        user_id = self.quiz_manager.user_get_id(update.effective_user.id)
+        user_id = self.user_manager.user_get_id(update.effective_user.id)
         role = self.user_manager.user_get_role(user_id)
         self.logger.info(f"User ID: {user_id} Role: {role}\nMessage : issued the /quiz command.")
         context.user_data.clear()

--- a/test/test_bot_runner.py
+++ b/test/test_bot_runner.py
@@ -6,7 +6,7 @@ pytest.importorskip("telegram")
 from telegram import Update, Bot
 from telegram.ext import CallbackContext
 from app.bot_runner import QuizBot
-from app.handlers import _escape_markdown
+from app.handlers import _escape_markdown, SELECTING_ACTION
 from app import main_menu_text
 
 @pytest.fixture
@@ -59,7 +59,7 @@ async def test_command_restart(bot_instance, mock_update, mock_context):
         parse_mode="MarkdownV2",
         reply_markup=MagicMock.ANY
     )
-    assert mock_context.user_data["state"] == "SELECTING_ACTION"
+    assert mock_context.user_data["state"] == SELECTING_ACTION
 
 @pytest.mark.asyncio
 async def test_command_career(bot_instance, mock_update, mock_context):


### PR DESCRIPTION
## Summary
- fix `command_quiz` so it uses `user_manager.user_get_id`
- adjust test for state constant in `command_restart`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685ba3aa134c8325b86c7b9f65c4c6f9