### PR TITLE
Add timezone configuration

### DIFF
--- a/app/bot_runner.py
+++ b/app/bot_runner.py
@@ -22,6 +22,7 @@ from .handlers import(
     extract_list_of_main_operations, extract_list_of_question_changing_operations, extract_list_of_report_operations, extract_list_of_question_operations
 )
 import random, time
+import pytz
 
 
 class QuizBot:
@@ -32,7 +33,13 @@ class QuizBot:
         self.user_manager = UserManager(staff_json_path,logger)
         self.report_manager = ReportManager(reports_json_path,logger)
         self.persistence = PicklePersistence('quiz_bot_data.pkl')
-        self.application = Application.builder().token(self.token).persistence(self.persistence).build()
+        self.application = (
+            Application.builder()
+            .token(self.token)
+            .persistence(self.persistence)
+            .timezone(pytz.UTC)
+            .build()
+        )
         self.logger = logger
         try:
             with open("data/career_questions.json", "r", encoding="utf-8") as f:

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,5 @@ python-telegram-bot==22.0
 sniffio==1.3.1
 tornado==6.4.2
 typing_extensions==4.12.2
+pytz>=2024.1
+tzlocal<3


### PR DESCRIPTION
## Summary
- add pytz and tzlocal to requirements
- configure quiz application timezone

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc300126c83259c73be03313fa187