### PR TITLE
Use logger in loaders and managers

### DIFF
--- a/app/bot_runner.py
+++ b/app/bot_runner.py
@@ -1069,9 +1069,9 @@ class QuizBot:
         role = self.user_manager.user_get_role(user_id)
         context.user_data["report"] = None
         report_list = self.report_manager.report_list()
-        print(report_list)
+        self.logger.debug(report_list)
         if not report_list:
-            print("No reports available")
+            self.logger.info("No reports available")
             await context.bot.send_message(
                 chat_id=update.effective_chat.id, 
                 text=_escape_markdown("_No reports available._"), 

--- a/app/quiz_manager.py
+++ b/app/quiz_manager.py
@@ -65,13 +65,12 @@ class QuizManager:
         return [question.id for question in self.questions_db.values() if question.language.lower() != language.lower()]
     
     def save_dictioanry_to_json(self, path: str):
-        print("OK savedict")
+        self.logger.info("Saving questions dictionary to JSON")
         self.question_loader.save_to_file(path, self.questions_db)
 
     def quiz_delete_question(self, question_id: int):
-        print("OK delete")
+        self.logger.info(f"Deleting question {question_id}")
         self.questions_db.pop(question_id, None)
-        print("OK delete2")
         self.save_dictioanry_to_json(self.question_file)
 
     def quiz_score(self, correct: int, wrong: int):

--- a/utils/json_loader.py
+++ b/utils/json_loader.py
@@ -4,12 +4,16 @@ import json
 import datetime
 from typing import Dict, Any
 
-from quiz_bot.question import Question
+from app.question import Question
+import logging
 
 
 class JSONQuestionsLoader:
 
-# Mwtgod to load the questions from the file
+    def __init__(self, logger: logging.Logger):
+        self.logger = logger
+
+    # Method to load the questions from the file
     def load_from_file(self, path: str) -> Dict[int, Question]:
         with open(path, "r", encoding="utf-8") as f:
             questions_list = json.load(f)
@@ -27,7 +31,9 @@ class JSONQuestionsLoader:
             q = Question(text, options, correct_index, verified, explanation, topic,id,language)
             questions_dict[i] = q
         current_time = datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-        print(f"[{current_time}] Loaded {len(questions_dict)} questions from {path}")
+        self.logger.info(
+            f"[{current_time}] Loaded {len(questions_dict)} questions from {path}"
+        )
         return questions_dict
     
 # Method to save the questions to the file
@@ -55,4 +61,6 @@ class JSONQuestionsLoader:
             json.dump(questions_list, f, ensure_ascii=False, indent=4)
         
         current_time = datetime.datetime.now().strftime("%d/%m/%Y %H:%M:%S")
-        print(f"[{current_time}] Saved {len(questions_dict)} questions to {path}")
+        self.logger.info(
+            f"[{current_time}] Saved {len(questions_dict)} questions to {path}"
+        )

--- a/utils/questions_loader.py
+++ b/utils/questions_loader.py
@@ -55,7 +55,7 @@ class QuestionsLoader:
             }
             questions_list.append(q_data)
         try:
-            logging.info(f"Saving {len(questions_list)} questions to {path}")
+            self.logger.info(f"Saving {len(questions_list)} questions to {path}")
             with open(path, "w", encoding="utf-8") as f:
                 json.dump(questions_list, f, ensure_ascii=False, indent=4)
         except FileNotFoundError:

--- a/utils/reports_loader.py
+++ b/utils/reports_loader.py
@@ -48,7 +48,7 @@ class ReportLoader:
             }
             report_list.append(report_data)
         try:
-            logging.info(f"Saving {len(report_list)} reports to {path}")
+            self.logger.info(f"Saving {len(report_list)} reports to {path}")
             with open(path, "w", encoding="utf-8") as f:
                 json.dump(report_list, f, ensure_ascii=False, indent=4)
         except FileNotFoundError:


### PR DESCRIPTION
## Summary
- inject logger into `JSONQuestionsLoader`
- log saves and loads in loaders
- use logger in `QuizManager`
- replace debug prints in `QuizBot`

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685bc6cfc6c08325b5a5a6415b9fe33b